### PR TITLE
Don't add anything to $rootScope by default; export the changeLanguage function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ you before passing to l20n.
 Configuration
 -------------
 
-Locale is stored in `localStorage`. The `localStorage` key, the `$rootScope` property that stores the locale on
-runtime as well as the name of the locale switching function attached to the `$rootScope` are customizable:
+Locale is stored in `localStorage`. The `localStorage` key as well al the `$rootScope` property that stores
+the locale are customizable:
 
-    myApp.config(["l20nProvider", function(l20nProvider) {
-      l20nProvider.localeStorageKey = 'myAppLocaleKey';            // default: 'locale'
-      l20nProvider.localeProperty = 'myAppLocale';                 // default: 'locale'
-      l20nProvider.changeLocaleFunctionName = 'myAppChangeLocale'; // default: 'changeLocale'
-    }]);
+```js
+myApp.config(["l20nProvider", function(l20nProvider) {
+  l20nProvider.localeStorageKey = 'myAppLocaleKey';    // default: 'locale'
+  l20nProvider.localeProperty = 'myAppLocale';         // default: none
+}]);
+```
+
+If the `localeProperty` is not specified, nothing will be saved to `$rootScope`.
 
 Minification and linting
 ------------------------


### PR DESCRIPTION
cc @jrencz. I wanted to stop adding stuff to the `$rootScope` by default as that's not the bes practice. Also, the function to change the locale doesn't need to be attached to anything by default; I changed it to be exported instead.
