### PR TITLE
Added empty attribute checking

### DIFF
--- a/src/ng-l20n.js
+++ b/src/ng-l20n.js
@@ -88,6 +88,14 @@
              */
             return function (scope, element, attrs) {
                 attrs.$observe('l20n', function () {
+                    // Checking if the attribute is truthy prevents from passing an empty translation key to l20n.
+                    // If an empty key is used on any node then l20n won't translate neither that node nor any of
+                    // the following nodes in the entire document. In the worst case scenario this may lead
+                    // to a permanent l20n failure f the empty key occurs at the very beginning of the document.
+                    if (!attrs.l20n) {
+                        return;
+                    }
+
                     // Remove possible previous listeners
                     document.removeEventListener('l20n:dataupdated', localizeCurrentNode);
 


### PR DESCRIPTION
If an empty key is used on any node then l20n won't translate neither that node nor any of the following nodes in the entire document. In the worst case scenario this may lead to a permanent l20n failure f the empty key occurs at the very beginning of the document.

This also allows module users not to take care if the key is defined. Maybe some debug mode could be introduced?
