### PR TITLE
Do not localize comment nodes

### DIFF
--- a/src/ng-l20n.js
+++ b/src/ng-l20n.js
@@ -91,6 +91,11 @@
 
                 link: function (scope, element, attrs) {
                     function localizeCurrentNode() {
+                        // l20n cant handle localization of comment nodes, throwing an error in the process.
+                        // Do not pass comment nodes to l20n for localization.
+                        if(element[0].nodeType === Node.COMMENT_NODE){
+                            return;
+                        }
                         documentL10n.localizeNode(element[0]);
                     }
 


### PR DESCRIPTION
l20n can't handle localization of comment nodes, throwing an error. This commit makes sure that comment nodes are not passed to l20n for localization.